### PR TITLE
Fix ClusterRole permission issues

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -140,11 +140,11 @@ uninstall: manifests kustomize ## Uninstall CRDs from the K8s cluster specified 
 	$(KUSTOMIZE) build config/crd | $(KUBECTL) delete --ignore-not-found=$(ignore-not-found) -f -
 
 .PHONY: helm-deploy
-helm-deploy: 
+helm-deploy: helm
 	helm upgrade -n pipeline-operator-system --create-namespace --install pipeline-operator ./charts/pipeline-operator
 
 .PHONY: helm-undeploy
-helm-undeploy:
+helm-undeploy: helm
 	helm uninstall -n pipeline-operator-system pipeline-operator
 
 .PHONY: deploy

--- a/charts/pipeline-operator/templates/manager-rbac.yaml
+++ b/charts/pipeline-operator/templates/manager-rbac.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
   {{- include "pipeline-operator.labels" . | nindent 4 }}
 rules:
-- apiGroups: 
+- apiGroups:
   - ""
   resources:
   - pods

--- a/charts/pipeline-operator/templates/pipeline-editor-rbac.yaml
+++ b/charts/pipeline-operator/templates/pipeline-editor-rbac.yaml
@@ -1,0 +1,28 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ include "pipeline-operator.fullname" . }}-pipeline-editor-role
+  labels:
+    app.kubernetes.io/component: rbac
+    app.kubernetes.io/created-by: pipeline-operator
+    app.kubernetes.io/part-of: pipeline-operator
+  {{- include "pipeline-operator.labels" . | nindent 4 }}
+rules:
+- apiGroups:
+  - pipeline.1eedaegon.github.io
+  resources:
+  - pipelines
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - pipeline.1eedaegon.github.io
+  resources:
+  - pipelines/status
+  verbs:
+  - get

--- a/charts/pipeline-operator/templates/pipeline-viewer-rbac.yaml
+++ b/charts/pipeline-operator/templates/pipeline-viewer-rbac.yaml
@@ -1,0 +1,24 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ include "pipeline-operator.fullname" . }}-pipeline-viewer-role
+  labels:
+    app.kubernetes.io/component: rbac
+    app.kubernetes.io/created-by: pipeline-operator
+    app.kubernetes.io/part-of: pipeline-operator
+  {{- include "pipeline-operator.labels" . | nindent 4 }}
+rules:
+- apiGroups:
+  - pipeline.1eedaegon.github.io
+  resources:
+  - pipelines
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - pipeline.1eedaegon.github.io
+  resources:
+  - pipelines/status
+  verbs:
+  - get

--- a/charts/pipeline-operator/templates/run-crd.yaml
+++ b/charts/pipeline-operator/templates/run-crd.yaml
@@ -156,7 +156,7 @@ spec:
                     type: string
                 type: object
               trigger:
-                type: boolean
+                type: string
               volumes:
                 items:
                   properties:

--- a/charts/pipeline-operator/templates/run-editor-rbac.yaml
+++ b/charts/pipeline-operator/templates/run-editor-rbac.yaml
@@ -1,0 +1,28 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ include "pipeline-operator.fullname" . }}-run-editor-role
+  labels:
+    app.kubernetes.io/component: rbac
+    app.kubernetes.io/created-by: pipeline-operator
+    app.kubernetes.io/part-of: pipeline-operator
+  {{- include "pipeline-operator.labels" . | nindent 4 }}
+rules:
+- apiGroups:
+  - pipeline.1eedaegon.github.io
+  resources:
+  - runs
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - pipeline.1eedaegon.github.io
+  resources:
+  - runs/status
+  verbs:
+  - get

--- a/charts/pipeline-operator/templates/run-viewer-rbac.yaml
+++ b/charts/pipeline-operator/templates/run-viewer-rbac.yaml
@@ -1,0 +1,24 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ include "pipeline-operator.fullname" . }}-run-viewer-role
+  labels:
+    app.kubernetes.io/component: rbac
+    app.kubernetes.io/created-by: pipeline-operator
+    app.kubernetes.io/part-of: pipeline-operator
+  {{- include "pipeline-operator.labels" . | nindent 4 }}
+rules:
+- apiGroups:
+  - pipeline.1eedaegon.github.io
+  resources:
+  - runs
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - pipeline.1eedaegon.github.io
+  resources:
+  - runs/status
+  verbs:
+  - get

--- a/charts/pipeline-operator/templates/task-editor-rbac.yaml
+++ b/charts/pipeline-operator/templates/task-editor-rbac.yaml
@@ -1,0 +1,28 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ include "pipeline-operator.fullname" . }}-task-editor-role
+  labels:
+    app.kubernetes.io/component: rbac
+    app.kubernetes.io/created-by: pipeline-operator
+    app.kubernetes.io/part-of: pipeline-operator
+  {{- include "pipeline-operator.labels" . | nindent 4 }}
+rules:
+- apiGroups:
+  - pipeline.1eedaegon.github.io
+  resources:
+  - tasks
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - pipeline.1eedaegon.github.io
+  resources:
+  - tasks/status
+  verbs:
+  - get

--- a/charts/pipeline-operator/templates/task-viewer-rbac.yaml
+++ b/charts/pipeline-operator/templates/task-viewer-rbac.yaml
@@ -1,0 +1,24 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ include "pipeline-operator.fullname" . }}-task-viewer-role
+  labels:
+    app.kubernetes.io/component: rbac
+    app.kubernetes.io/created-by: pipeline-operator
+    app.kubernetes.io/part-of: pipeline-operator
+  {{- include "pipeline-operator.labels" . | nindent 4 }}
+rules:
+- apiGroups:
+  - pipeline.1eedaegon.github.io
+  resources:
+  - tasks
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - pipeline.1eedaegon.github.io
+  resources:
+  - tasks/status
+  verbs:
+  - get

--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -31,6 +31,7 @@ patches:
 # If you want your controller-manager to expose the /metrics
 # endpoint w/o any authn/z, please comment the following line.
 - path: manager_auth_proxy_patch.yaml
+- path: manager_role.yaml
 
 # [WEBHOOK] To enable webhook, uncomment all the sections with [WEBHOOK] prefix including the one in
 # crd/kustomization.yaml

--- a/config/default/manager_role.yaml
+++ b/config/default/manager_role.yaml
@@ -1,0 +1,62 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: manager-role
+rules:
+- apiGroups: 
+  - ""
+  resources:
+  - pods
+  - pods/status
+  - persistentvolumeclaims
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - batch
+  resources:
+  - jobs
+  - jobs/status
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - pipeline.1eedaegon.github.io
+  resources:
+  - pipelines
+  - pipelines/status
+  - tasks
+  - runs
+  - runs/status
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - pipeline.1eedaegon.github.io
+  resources:
+  - tasks/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - pipeline.1eedaegon.github.io
+  resources:
+  - tasks/status
+  verbs:
+  - get
+  - patch
+  - update

--- a/config/rbac/kustomization.yaml
+++ b/config/rbac/kustomization.yaml
@@ -9,6 +9,12 @@ resources:
 - role_binding.yaml
 - leader_election_role.yaml
 - leader_election_role_binding.yaml
+- pipeline_editor_role.yaml
+- pipeline_viewer_role.yaml
+- run_editor_role.yaml
+- run_viewer_role.yaml
+- task_editor_role.yaml
+- task_viewer_role.yaml
 # Comment the following 4 lines if you want to disable
 # the auth proxy (https://github.com/brancz/kube-rbac-proxy)
 # which protects your /metrics endpoint.


### PR DESCRIPTION
# About this PR

This PR fixes known issue in below, during v0.0.1 release / deployment.

* Disabled helm .PHONY depeendency in helm-deploy / helm-undeploy for preventing immutable resources
  * especially manager-role ClusterRole

# Changes

* Use helm on helm-deploy / helm-undeploy
* Add rbac resources on kustomize definition
* Add manager-role patch on kustomize definition
* Add generated helm resources